### PR TITLE
Upgrade - Bumping Django and loosely pinning it to 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.2.3
+[Full Changelog](https://github.com/uktrade/directory-signature-auth/pull/35) (2024-01-03)
+- loosely pin django to ~=4.2 to allow for security fixes
+
 ### 5.2.2
 [Full Changelog](https://github.com/uktrade/directory-signature-auth/pull/35) (2023-07-05)
 - bump django to 4.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 5.2.3
-[Full Changelog](https://github.com/uktrade/directory-signature-auth/pull/35) (2024-01-03)
+[Full Changelog](https://github.com/uktrade/directory-signature-auth/pull/36) (2024-01-03)
 - loosely pin django to ~=4.2 to allow for security fixes
 
 ### 5.2.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=3.2.19, ~=4.2.7",
+        "django>=3.2.19, ~=4.2.3",
         "djangorestframework>=3.4.7,<4.0.0",
         "mohawk>=0.3.4,<2.0.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sigauth",
-    version="5.2.2",
+    version="5.2.3",
     url="https://github.com/uktrade/directory-signature-auth",
     license="MIT",
     author="Department for International Trade",
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=3.2.19,<=4.2.3",
+        "django>=3.2.19, ~=4.2.3",
         "djangorestframework>=3.4.7,<4.0.0",
         "mohawk>=0.3.4,<2.0.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=3.2.19, ~=4.2.3",
+        "django>=3.2.19, ~=4.2.7",
         "djangorestframework>=3.4.7,<4.0.0",
         "mohawk>=0.3.4,<2.0.0",
     ],


### PR DESCRIPTION
Bumping django and loosely pinning it to 4.2 to accommodate future security fixes in patched versions.
