### PR TITLE
bump django to min 4.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.2.5
+[Full Changelog]() (2024-02-2)
+- Set Django Minimum 4.2.8 and Maximum 5.0
+
 ### 5.2.4
 [Full Changelog](https://github.com/uktrade/directory-signature-auth/pull/37) (2024-01-22)
 - Set Django Minimum 4.2.7 and Maximum 4,2,8

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sigauth",
-    version="5.2.4",
+    version="5.2.5",
     url="https://github.com/uktrade/directory-signature-auth",
     license="MIT",
     author="Department for International Trade",
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=4.2.7,<4.2.8",
+        "django>=4.2.8,<5.0",
         "djangorestframework>=3.4.7,<4.0.0",
         "mohawk>=0.3.4,<2.0.0",
     ],


### PR DESCRIPTION
bump django to min 4.2.8

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.

